### PR TITLE
Add basic message ingestion

### DIFF
--- a/src/main/java/com/delte/api/controller/MessageController.java
+++ b/src/main/java/com/delte/api/controller/MessageController.java
@@ -1,0 +1,28 @@
+package com.delte.api.controller;
+
+import com.delte.api.mapper.MessageDto;
+import com.delte.api.service.MessageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("message")
+public class MessageController {
+
+    @Autowired
+    private MessageService messageService;
+
+    @PostMapping
+    public ResponseEntity<MessageDto> save(@RequestBody MessageDto messageDto) {
+        return new ResponseEntity<>(messageService.saveMessage(messageDto), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MessageDto>> getAll() {
+        return new ResponseEntity<>(messageService.getAllMessages(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/delte/api/mapper/MessageDto.java
+++ b/src/main/java/com/delte/api/mapper/MessageDto.java
@@ -1,0 +1,19 @@
+package com.delte.api.mapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageDto {
+    private UUID messageId;
+    private UUID userId;
+    private String content;
+    private Date receivedAt;
+    private String category;
+}

--- a/src/main/java/com/delte/api/model/Message.java
+++ b/src/main/java/com/delte/api/model/Message.java
@@ -1,0 +1,30 @@
+package com.delte.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "messages")
+public class Message implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID messageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @JsonIgnore
+    private User user;
+
+    private String content;
+
+    private Date receivedAt;
+
+    private String category;
+}

--- a/src/main/java/com/delte/api/repository/MessageRepository.java
+++ b/src/main/java/com/delte/api/repository/MessageRepository.java
@@ -1,0 +1,17 @@
+package com.delte.api.repository;
+
+import com.delte.api.mapper.MessageDto;
+import com.delte.api.model.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface MessageRepository extends JpaRepository<Message, UUID> {
+
+    @Query("select new com.delte.api.mapper.MessageDto(m.messageId, m.user.userId, m.content, m.receivedAt, m.category) from Message m")
+    List<MessageDto> findAllMessages();
+}

--- a/src/main/java/com/delte/api/service/MessageService.java
+++ b/src/main/java/com/delte/api/service/MessageService.java
@@ -1,0 +1,10 @@
+package com.delte.api.service;
+
+import com.delte.api.mapper.MessageDto;
+
+import java.util.List;
+
+public interface MessageService {
+    MessageDto saveMessage(MessageDto messageDto);
+    List<MessageDto> getAllMessages();
+}

--- a/src/main/java/com/delte/api/service/impl/MessageServiceImpl.java
+++ b/src/main/java/com/delte/api/service/impl/MessageServiceImpl.java
@@ -1,0 +1,62 @@
+package com.delte.api.service.impl;
+
+import com.delte.api.mapper.MessageDto;
+import com.delte.api.model.Message;
+import com.delte.api.repository.MessageRepository;
+import com.delte.api.repository.UserRepository;
+import com.delte.api.service.MessageService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class MessageServiceImpl implements MessageService {
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public MessageDto saveMessage(MessageDto messageDto) {
+        log.info("save message : {}", messageDto);
+        Message message = new Message();
+        if (!ObjectUtils.isEmpty(messageDto.getMessageId())) {
+            message = messageRepository.findById(messageDto.getMessageId()).orElse(new Message());
+        }
+        message.setContent(messageDto.getContent());
+        message.setReceivedAt(messageDto.getReceivedAt());
+        message.setCategory(categorize(messageDto.getContent()));
+        if (!ObjectUtils.isEmpty(messageDto.getUserId())) {
+            userRepository.findById(messageDto.getUserId()).ifPresent(message::setUser);
+        }
+        Message saved = messageRepository.save(message);
+        messageDto.setMessageId(saved.getMessageId());
+        messageDto.setCategory(saved.getCategory());
+        return messageDto;
+    }
+
+    @Override
+    public List<MessageDto> getAllMessages() {
+        return messageRepository.findAllMessages();
+    }
+
+    private String categorize(String text) {
+        if (text == null) {
+            return "OTHER";
+        }
+        String lower = text.toLowerCase();
+        if (lower.contains("spent") || lower.contains("paid") || lower.contains("debited")) {
+            return "EXPENSE";
+        } else if (lower.contains("credited")) {
+            return "INCOME";
+        }
+        return "OTHER";
+    }
+}


### PR DESCRIPTION
## Summary
- add `Message` entity and `MessageDto`
- create repository, service, and controller for messages
- implement simple keyword-based categorization

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fd436eda4832a899e613dc24ee603